### PR TITLE
feat(schema-ref): support schema generator instead of schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3887,12 +3887,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3907,17 +3909,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4047,6 +4052,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4061,6 +4067,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4068,12 +4075,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4092,6 +4101,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4172,7 +4182,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4184,6 +4195,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4305,6 +4317,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/model-creator.test.ts
+++ b/test/model-creator.test.ts
@@ -66,8 +66,21 @@ describe('module creator', () => {
             expect(model.collection.name).toBe(`${testCollectionPrefix}_reality-${testReality}`);
         });
 
+        test('calling model creator twice return created model, not trowing error', () => {
+            const first = modelCreator(context);
+            const second = modelCreator(context);
+            expect(first).toBe(second);
+        });
+
         test('created model contains given schema', () => {
-            expect(model.schema).toBe(personSchema);
+            const resultPaths = (model.schema as any).paths;
+            const firstPaths = (personSchema as any).paths;
+            expect(resultPaths.name).toEqual(firstPaths.name);
+            expect(resultPaths.age).toEqual(firstPaths.age);
+        });
+
+        test('working with clone of the schema, not the schema itself', () => {
+            expect(model.schema).not.toBe(personSchema);
         });
 
         test('created model contains field createdBy of type string', () => {


### PR DESCRIPTION
allow to get schema generator instead of schema in model creator, this allow user to use refs in the
schema(when the collection name that we reffers is containing realitu id)